### PR TITLE
Added required version key to manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "yeelight_v2",
   "name": "YeelightV2",
-  "versioN": "1.0.0",
+  "version": "1.0.0",
   "documentation": "https://www.home-assistant.io/integrations/yeelight",
   "codeowners": [
     "@rytilahti",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "yeelight_v2",
   "name": "YeelightV2",
+  "versioN": "1.0.0",
   "documentation": "https://www.home-assistant.io/integrations/yeelight",
   "codeowners": [
     "@rytilahti",


### PR DESCRIPTION
Since Home Assistant 2021.6, HA requires custom integrations to have a version key in the manifest.json:

`2021-05-31 20:55:51 ERROR (MainThread) [homeassistant.loader] No 'version' key in the manifest file for custom integration 'yeelight_v2'. As of Home Assistant 2021.6, this integration will no longer be loaded. Please report this to the maintainer of 'yeelight_v2'`

This PR fixes that